### PR TITLE
Feature/add config file multihost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+cfe_sbn_bridge_plugin
+======================
+
+This bridge allows to share information between cFE and ROS2 systems
+using SBN. 
+
+To run:
+
+```
+ros2 launch cfe_sbn_plugin cfe_sbn_bridge.launch.py
+```
+
+This launch file accepts as argument **cfe_sbn_config** . This file contains 
+configuration information for the bridge. Most of the parameters can be used
+with its default values. You'll only want to modify the parameters that 
+define the location of your gsw machine, specifically:
+
+- peer_ip
+- peer_port
+- peer_processor_id
+
+Currently, we have available 2 configuration files to use, both
+located in cfe_sbn_plugin/config:
+
+- cfe_sbn_config.yaml: File applicable for a single-host setup. This is the default.
+- cfe_sbn_config_multihost.yaml:  File applicable for a multihost setup, such as the one used by brash docker.
+
+You can create your own file using these files as reference.

--- a/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
+++ b/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
@@ -70,7 +70,7 @@ class FSWPlugin(FSWPluginInterface):
                 integer_value
         self._node.get_logger().info("  using peer_processor_id: " + str(self._peer_processor_id))
 
-        self._node.declare_parameter('plugin_params.peer_spacecraft_id', 0x44)
+        self._node.declare_parameter('plugin_params.peer_spacecraft_id', 0x42)
         self._peer_spacecraft_id = self._node.get_parameter('plugin_params.peer_spacecraft_id').get_parameter_value(). \
                 integer_value
         self._node.get_logger().info("  using peer_spacecraft_id: " + str(self._peer_spacecraft_id))

--- a/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
+++ b/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
@@ -48,42 +48,30 @@ class FSWPlugin(FSWPluginInterface):
         self._node.get_logger().info("  using udp_receive_port: " + str(self._udp_receive_port))
 
         self._node.declare_parameter('plugin_params.peer_port', 2234)
-        self._peer_port = os.environ.get("FSW_SBN_PORT")
-        if not self._peer_port:
-            self._peer_port = self._node.get_parameter('plugin_params.peer_port'). \
+        self._peer_port = self._node.get_parameter('plugin_params.peer_port'). \
                 get_parameter_value().integer_value
-        else:
-            self._peer_port = int(self._peer_port)
         self._node.get_logger().info("  using peer_port: " + str(self._peer_port))
 
         # udp_ip_desc = ParameterDescriptor(description="IP Address to bind on for receiving traffic")
         self._node.declare_parameter('plugin_params.udp_receive_ip', '0.0.0.0')#,udp_ip_desc)
-        self._udp_ip = os.environ.get("SBN_BIND_IP")
-        if not self._udp_ip:
-            self._udp_ip = self._node.get_parameter('plugin_params.udp_receive_ip').get_parameter_value(). \
+        self._udp_ip = self._node.get_parameter('plugin_params.udp_receive_ip').get_parameter_value(). \
                 string_value
         self._node.get_logger().info("  using udp_receive_ip: " + self._udp_ip)
 
         # TODO: Consider syntax that permits defining multiple SBN peers
         # peer_udp_ip_desc = ParameterDescriptor(description="IP Address of primary SBN peer")
         self._node.declare_parameter('plugin_params.peer_ip', '127.0.0.1')#,udp_ip_desc)
-        self._peer_udp_ip = os.environ.get("FSW_IP") # This ENV is used for both SBN and GSW
-        if not self._peer_udp_ip:
-            self._peer_udp_ip = self._node.get_parameter('plugin_params.peer_ip').get_parameter_value(). \
+        self._peer_udp_ip = self._node.get_parameter('plugin_params.peer_ip').get_parameter_value(). \
                 string_value
         self._node.get_logger().info("  using peer_ip: " + self._peer_udp_ip)
         
         self._node.declare_parameter('plugin_params.peer_processor_id', 1)
-        self._peer_processor_id = int(os.environ.get("FSW_SBN_PROCESSOR_ID"))
-        if not self._peer_processor_id:
-            self._peer_processor_id = self._node.get_parameter('plugin_params.peer_processor_id').get_parameter_value(). \
+        self._peer_processor_id = self._node.get_parameter('plugin_params.peer_processor_id').get_parameter_value(). \
                 integer_value
         self._node.get_logger().info("  using peer_processor_id: " + str(self._peer_processor_id))
 
         self._node.declare_parameter('plugin_params.peer_spacecraft_id', 0x44)
-        self._peer_spacecraft_id = os.environ.get("FSW_SBN_SPACECRAFT_ID")
-        if not self._peer_spacecraft_id:
-            self._peer_spacecraft_id = self._node.get_parameter('plugin_params.peer_spacecraft_id').get_parameter_value(). \
+        self._peer_spacecraft_id = self._node.get_parameter('plugin_params.peer_spacecraft_id').get_parameter_value(). \
                 integer_value
         self._node.get_logger().info("  using peer_spacecraft_id: " + str(self._peer_spacecraft_id))
 

--- a/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
+++ b/cfe_sbn_plugin/cfe_sbn_plugin/cfe_sbn_plugin.py
@@ -33,13 +33,6 @@ class FSWPlugin(FSWPluginInterface):
         self._node.get_logger().info("Setting up cFE-SBN bridge plugin")
         # self._routing_service = None
 
-        self._node.declare_parameter('plugin_params.cfs_root', '~/code/cFS')
-        self._cfs_root = self._node.get_parameter('plugin_params.cfs_root').get_parameter_value(). \
-            string_value
-        if '~' in self._cfs_root:
-            self._cfs_root = os.path.expanduser(self._cfs_root)
-        self._node.get_logger().info("  using cfs_root: " + self._cfs_root)
-
         self._node.declare_parameter('plugin_params.msg_pkg', 'cfe_msgs')
         self._msg_pkg = self._node.get_parameter('plugin_params.msg_pkg').get_parameter_value(). \
             string_value
@@ -51,16 +44,48 @@ class FSWPlugin(FSWPluginInterface):
             get_parameter_value().integer_value
         self._node.get_logger().info("  using udp_receive_port: " + str(self._udp_receive_port))
 
-        self._node.declare_parameter('plugin_params.udp_send_port', 1235)
-        self._udp_send_port = self._node.get_parameter('plugin_params.udp_send_port'). \
-            get_parameter_value().integer_value
-        self._node.get_logger().info("  using udp_send_port: " + str(self._udp_send_port))
+        
+        self._node.declare_parameter('plugin_params.peer_port', 1235)
+        self._peer_port = os.environ.get("FSW_SBN_PORT")
+        if not self._peer_port:
+            self._peer_port = self._node.get_parameter('plugin_params.peer_port'). \
+                get_parameter_value().integer_value
+        else:
+            self._peer_port = int(self._peer_port)
+        self._node.get_logger().info("  using peer_port: " + str(self._peer_port))
 
-        self._node.declare_parameter('plugin_params.udp_ip', '127.0.0.1')
-        self._udp_ip = self._node.get_parameter('plugin_params.udp_ip').get_parameter_value(). \
-            string_value
-        self._node.get_logger().info("  using udp_ip: " + self._udp_ip)
+        # udp_ip_desc = ParameterDescriptor(description="IP Address to bind on for receiving traffic")
+        self._node.declare_parameter('plugin_params.udp_receive_ip', '0.0.0.0')#,udp_ip_desc)
+        self._udp_ip = os.environ.get("SBN_BIND_IP")
+        if not self._udp_ip:
+            self._udp_ip = self._node.get_parameter('plugin_params.udp_receive_ip').get_parameter_value(). \
+                string_value
+        self._node.get_logger().info("  using udp_receive_ip: " + self._udp_ip)
 
+        # TODO: Consider syntax that permits defining multiple SBN peers
+        # peer_udp_ip_desc = ParameterDescriptor(description="IP Address of primary SBN peer")
+        self._node.declare_parameter('plugin_params.peer_ip', '127.0.0.1')#,udp_ip_desc)
+        self._peer_udp_ip = os.environ.get("FSW_IP") # This ENV is used for both SBN and GSW
+        if not self._peer_udp_ip:
+            self._peer_udp_ip = self._node.get_parameter('plugin_params.peer_ip').get_parameter_value(). \
+                string_value
+        self._node.get_logger().info("  using peer_ip: " + self._peer_udp_ip)
+        
+        self._node.declare_parameter('plugin_params.peer_processor_id', 1)
+        self._peer_processor_id = int(os.environ.get("FSW_SBN_PROCESSOR_ID"))
+        if not self._peer_processor_id:
+            self._peer_processor_id = self._node.get_parameter('plugin_params.peer_processor_id').get_parameter_value(). \
+                integer_value
+        self._node.get_logger().info("  using peer_processor_id: " + str(self._peer_processor_id))
+
+        self._node.declare_parameter('plugin_params.peer_spacecraft_id', 0x44)
+        self._peer_spacecraft_id = os.environ.get("FSW_SBN_SPACECRAFT_ID")
+        if not self._peer_spacecraft_id:
+            self._peer_spacecraft_id = self._node.get_parameter('plugin_params.peer_spacecraft_id').get_parameter_value(). \
+                integer_value
+        self._node.get_logger().info("  using peer_spacecraft_id: " + str(self._peer_spacecraft_id))
+
+        
         self._node.declare_parameter("plugin_params.processor_id", 0x2)
         self._processor_id = self._node.get_parameter('plugin_params.processor_id').get_parameter_value().integer_value
         self._node.declare_parameter("plugin_params.spacecraft_id", 0x42)
@@ -76,6 +101,7 @@ class FSWPlugin(FSWPluginInterface):
         self._rosout_file_max_length = self._node.get_parameter('plugin_params.rosout_file_max_length').get_parameter_value().integer_value
         self._node.declare_parameter("plugin_params.rosout_function_max_length", 32)
         self._rosout_function_max_length = self._node.get_parameter('plugin_params.rosout_function_max_length').get_parameter_value().integer_value
+
 
         # Create the subscribe/unsubscribe services.
         self._subscribe_srv = self._node.create_service(Subscribe,
@@ -140,8 +166,8 @@ class FSWPlugin(FSWPluginInterface):
                                                                     self.subscription_scanning_timer_callback)
 
         # TODO: Update cfg yaml to define a list of peers.
-        self._sbn_receiver.add_peer(self._udp_ip, self._udp_send_port, 0x42, 1)
-
+        self._sbn_receiver.add_peer(self._peer_udp_ip, self._peer_port, self._peer_spacecraft_id, self._peer_processor_id)
+        
         # Testing.  Subscribe to the /rosout topic to get the rosout messages.  This is on the flight side
         self._subscribe_srv = self._node.create_subscription(Log, '/rosout', self.rosout_callback, 10)
 

--- a/cfe_sbn_plugin/cfe_sbn_plugin/sbn_peer.py
+++ b/cfe_sbn_plugin/cfe_sbn_plugin/sbn_peer.py
@@ -70,6 +70,8 @@ class SBNPeer():
         self._udp_ip = udp_ip
         self._udp_port = udp_port
 
+        self._node.get_logger().info(f" Adding peer at {udp_ip}:{udp_port} for {sc_id}, {proc_id}")
+
         ## Local Spacecraft Identifier
         self._spacecraft_id = self._node.get_parameter('plugin_params.spacecraft_id').get_parameter_value().integer_value
 

--- a/cfe_sbn_plugin/config/cfe_sbn_config.yaml
+++ b/cfe_sbn_plugin/config/cfe_sbn_config.yaml
@@ -2,11 +2,9 @@ cfe_sbn_bridge:
   ros__parameters:
     plugin_name: cfe_sbn_plugin.cfe_sbn_plugin
     plugin_params:
-      cfs_root: ~/code/TL_cFS
       msg_pkg: cfe_msgs
       udp_receive_port: 2236
-      udp_send_port: 2234
-      udp_ip: '127.0.0.1'
+      udp_receive_ip: '0.0.0.0'
       spacecraft_id: 66
       processor_id: 3
       epoch_delta: 315532800
@@ -14,4 +12,5 @@ cfe_sbn_bridge:
       rosout_msg_max_length: 128
       rosout_file_max_length: 64
       rosout_function_max_length: 32
-
+      peer_ip: "127.0.0.1"
+      peer_port: 2234

--- a/cfe_sbn_plugin/config/cfe_sbn_config_multihost.yaml
+++ b/cfe_sbn_plugin/config/cfe_sbn_config_multihost.yaml
@@ -14,7 +14,7 @@ cfe_sbn_bridge:
       rosout_file_max_length: 64
       rosout_function_max_length: 32
       # fsw information
-      peer_ip: "127.0.0.1"
-      peer_port: 2234
-      peer_processor_id: 1        # Processor id (1 or 2, for cpu1 or cpu2)
+      peer_ip: "10.5.0.3"         # IP for fsw (if same machine, use 127.0.0.1) 
+      peer_port: 2235             # 2234 for cpu1, 2235 for cpu2
+      peer_processor_id: 2        # Processor id (1 or 2, for cpu1 - singlehost setup, or cpu2 - multihost setup)
 

--- a/cfe_sbn_plugin/launch/cfe_sbn_bridge.launch.py
+++ b/cfe_sbn_plugin/launch/cfe_sbn_bridge.launch.py
@@ -8,8 +8,8 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 def generate_launch_description():
 
     # Argument to set cfe_config file to use, dependent on your specific setup
-    # default: cfe_config.yaml is good for single-host setups 
-    # alternative: cfe_config_multihost.yaml is good for multihost setups, such as the docker demo 
+    # default: cfe_sbn_config.yaml is good for single-host setups 
+    # alternative: cfe_sbn_config_multihost.yaml is good for multihost setups, such as the docker demo 
     cfe_sbn_config = LaunchConfiguration('cfe_sbn_config')
     cfe_sbn_config_launch_arg = DeclareLaunchArgument('cfe_sbn_config', default_value='cfe_sbn_config.yaml',
                             description='cfe_sbn_config yaml file')

--- a/cfe_sbn_plugin/launch/cfe_sbn_bridge.launch.py
+++ b/cfe_sbn_plugin/launch/cfe_sbn_bridge.launch.py
@@ -2,21 +2,29 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 def generate_launch_description():
-    ld = LaunchDescription()
-    config = os.path.join(
+
+    # Argument to set cfe_config file to use, dependent on your specific setup
+    # default: cfe_config.yaml is good for single-host setups 
+    # alternative: cfe_config_multihost.yaml is good for multihost setups, such as the docker demo 
+    cfe_sbn_config = LaunchConfiguration('cfe_sbn_config')
+    cfe_sbn_config_launch_arg = DeclareLaunchArgument('cfe_sbn_config', default_value='cfe_sbn_config.yaml',
+                            description='cfe_sbn_config yaml file')
+
+    config = PathJoinSubstitution([
         get_package_share_directory('cfe_sbn_plugin'),
         'config',
-        'cfe_sbn_config.yaml'
-        )
+        cfe_sbn_config
+        ])
 
-    sbn_config = os.path.join(
+    sbn_config = PathJoinSubstitution([
         get_package_share_directory('juicer_util'),
         'config',
         'cfe_plugin_config.yaml'
-        )
+        ])
 
     node = Node(
         package='fsw_ros2_bridge',
@@ -24,5 +32,9 @@ def generate_launch_description():
         executable='fsw_ros2_bridge',
         parameters=[config, sbn_config]
     )
-    ld.add_action(node)
-    return ld
+
+    return LaunchDescription([
+      cfe_sbn_config_launch_arg,
+      node
+    ])
+

--- a/tools/tshark/package-lock.json
+++ b/tools/tshark/package-lock.json
@@ -12,6 +12,9 @@
         "blessed": "^0.1.81",
         "blessed-contrib": "^4.11.0",
         "yargs": "^17.6.2"
+      },
+      "bin": {
+        "brash_tshark": "brash_tshark.js"
       }
     },
     "node_modules/@colors/colors": {


### PR DESCRIPTION
This PR does a couple of things:

1. Delete os.get_environ() from cfe_sbn_plugin.py . The parameters that the bridge reads are now only read from  the configuration yaml file.
2. Update the launch file for cfe_sbn_plugin such that the user can set an argument for **cfe_sbn_config** . This way, a user can create a yaml specific for his setup (e.g. multihost, singlehost) and use this yaml when launching the bridge.
3.  Added a new yaml file (cfe_sbn_config_multihost.yaml) that corresponds to the Docker setup. 
4. Default config file is still the cfe_sbn_config.yaml file, which is suitable for the singlehost setup of the earliest tutorials.

Tested in both the single-host and multihost setups, each using the configuration files accordingly. Works as expected.